### PR TITLE
Set HTTP post/file max size to 500M

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -12,7 +12,7 @@ location __PATH__/ {
   index index.php;
 
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
-  #client_max_body_size 50M;
+  client_max_body_size 500M;
 
   try_files $uri $uri/ index.php;
   location ~ [^/]\.php(/|$) {

--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -419,8 +419,8 @@ chdir = __FINALPATH__
 ;php_admin_value[memory_limit] = 32M
 
 ; Common values to change to increase file upload limit
-; php_admin_value[upload_max_filesize] = 50M
-; php_admin_value[post_max_size] = 50M
+php_admin_value[upload_max_filesize] = 500M
+php_admin_value[post_max_size] = 500M
 ; php_admin_flag[mail.add_x_header] = Off
 
 ; Other common parameters


### PR DESCRIPTION
## Problem

- File upload of files larger than 20MB is not possible due to ynh defaults

## Solution

- Overriding the defaults by setting them to 500MB

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
