### PR TITLE
Latest version + fix permissions

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://repository.yeswiki.net/doryphore/yeswiki-doryphore-2021-11-04-6.zip
-SOURCE_SUM=f29d30506c0e69e7c0cb1a8f0b4a63bb798039bdf3c92ee93138c9bf8ea00754
+SOURCE_URL=https://repository.yeswiki.net/doryphore/yeswiki-doryphore-2022-01-16-13.zip  
+SOURCE_SUM=2239572babfbd46e8b79ac6333827c55225b2f70990d51e934e82fda8894165f
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=yeswiki-doryphore-2021-11-04-6.zip
+SOURCE_FILENAME=yeswiki-doryphore-2022-01-16-13.zip  

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -15,6 +15,19 @@ loginldap_version="2021-03-01-2"
 # PERSONAL HELPERS
 #=================================================
 
+# update directory right
+# | arg: app - The application's name ; default : yeswiki
+# | arg: final_path - The path of the application's folder
+#	yeswiki_update_dir_rights yeswiki /var/www/yeswiki
+yeswiki_update_dir_rights() {
+	local app="${1:-yeswiki}"
+	local final_path="${2}"
+  
+  chown -R $app:$app $final_path
+  chmod -R u=rwX,g=rX,o=rX $final_path
+  chmod -R g+rwX,o+rwX $final_path/{cache,files}
+}
+
 #=================================================
 # EXPERIMENTAL HELPERS
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -107,7 +107,7 @@ phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 #=================================================
 
 # Set right permissions for cURL install
-chown -R $app: $final_path
+chown -R $app:$app $final_path
 
 # Set the app as temporarily public for cURL call
 ynh_permission_update --permission="main" --add="visitors"
@@ -165,11 +165,7 @@ ynh_replace_string --match_string=");"\
 #=================================================
 
 # Set permissions to app files 
-chown -R root: $final_path
-chown -R $app $final_path/{cache,files,themes,tools,wakka.config.php}
-
-chown $app:www-data $final_path
-chmod o-rwx $final_path
+yeswiki_update_dir_rights $app $final_path
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/restore
+++ b/scripts/restore
@@ -70,11 +70,7 @@ ynh_restore_file --origin_path="$final_path"
 #=================================================
 
 # Restore permissions on app files
-chown -R root: $final_path
-chown -R $app $final_path/{cache,files,themes,tools,wakka.config.php}
-
-chown $app:www-data $final_path
-chmod o-rwx $final_path
+yeswiki_update_dir_rights $app $final_path
 
 #=================================================
 # RESTORE THE PHP-FPM CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -147,11 +147,7 @@ ynh_add_fpm_config --package="$extra_php_dependencies"
 #=================================================
 
 # Set permissions on app files
-chown -R root: $final_path
-chown -R $app $final_path/{cache,files,themes,tools,wakka.config.php}
-
-chown $app:www-data $final_path
-chmod o-rwx $final_path
+yeswiki_update_dir_rights $app $final_path
 
 #=================================================
 # RELOAD NGINX


### PR DESCRIPTION
## Problem

- YesWiki yunohost app was broken, due to removal of older versions in upstream repo
- a new version of YesWiki is out `2022-01-16-13`
- user had some file permission problem

## Solution

- helpers for file permissions thank to @j9rem
- some usefull merge and config update

## PR Status

- [x ] Code finished and ready to be reviewed/tested
- [x ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
