### PR TITLE
fix(security): file permissions only to user, add www-data group

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -23,9 +23,8 @@ yeswiki_update_dir_rights() {
 	local app="${1:-yeswiki}"
 	local final_path="${2}"
   
-  chown -R $app:$app $final_path
-  chmod -R u=rwX,g=rX,o=rX $final_path
-  chmod -R g+rwX,o+rwX $final_path/{cache,files}
+  chown -R $app:www-data $final_path
+  chmod -R u=rwx,g=rx,o-rwx $final_path
 }
 
 #=================================================


### PR DESCRIPTION
## Problem

- Linter was not happy with [file permissions](https://ci-apps.yunohost.org/ci/job/5447)

## Solution

- no rights for other, readonly for groups
- add www-data group so that nginx still can serve app

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
