### PR TITLE
add missing dep to php82-ldap and fix upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ However, with a YesWiki we can build a website with multiple uses:
 - Cultivate a bit of freedom...
 
 
-**Shipped version:** 4.4.1~ynh1
+**Shipped version:** 4.4.2~ynh1
 
 **Demo:** https://ferme.yeswiki.net/?CreerSonWiki
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -26,7 +26,7 @@ Néanmoins, avec un YesWiki on peut fabriquer un site internet aux usages multip
 - Cultiver un bout de liberté...
 
 
-**Version incluse :** 4.4.1~ynh1
+**Version incluse :** 4.4.2~ynh1
 
 **Démo :** https://ferme.yeswiki.net/?CreerSonWiki
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -72,7 +72,7 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages = "mariadb-server, php8.2-zip, php8.2-curl, php8.2-gd, php8.2-dom, php8.2-mysql"
+    packages = "mariadb-server, php8.2-zip, php8.2-curl, php8.2-gd, php8.2-dom, php8.2-mysql, php8.2-ldap"
 
     [resources.database]
     type = "mysql"

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "YesWiki"
 description.en = "Wiki that is quick and easy to use"
 description.fr = "Wiki facile et rapide à prendre en main"
 
-version = "4.4.1~ynh1"
+version = "4.4.2~ynh1"
 
 maintainers = ["Florian Schmitt", "Nils Van Zuijlen", "Plumf"]
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -25,7 +25,7 @@ then
 
 	# Download, check integrity, uncompress and patch the source from app.src
 	# TODO : find a way to sync stable extensions list to avoid hardcoded extensions folders to keep
-	ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep=".env wakka.config.php files/ custom/ private/ themes/ tools/accountactivationbyemail/ tools/advancedsearch/ tools/benevolat/ tools/ferme/ tools/fontautoinstall/ tools/ipblock/ tools/lms/ tools/login-sso/ tools/logincas/ tools/loginldap/ tools/maintenance/ tools/multideletepages/ tools/nextcloudconnector/ tools/publication/ tools/qrcode/ tools/stats/ tools/tabdyn/ tools/twolevels/ tools/webhooks"
+	ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep=".env wakka.config.php files custom private themes tools/accountactivationbyemail tools/advancedsearch tools/benevolat tools/ferme tools/fontautoinstall tools/ipblock tools/lms tools/login-sso tools/logincas tools/loginldap tools/maintenance tools/multideletepages tools/nextcloudconnector tools/publication tools/qrcode tools/stats tools/tabdyn tools/twolevels tools/webhooks"
 
 	ynh_replace_string --match_string="yeswiki_release' \?=> \?'.*',$" --replace_string="yeswiki_release' => '$(ynh_app_upstream_version)'," --target_file="$install_dir/wakka.config.php"
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -25,7 +25,7 @@ then
 
 	# Download, check integrity, uncompress and patch the source from app.src
 	# TODO : find a way to sync stable extensions list to avoid hardcoded extensions folders to keep
-	ynh_setup_source --dest_dir="$install_dir" --full-replace=1 --keep='.env wakka.config.php files/ custom/ private/ themes/ tools/accountactivationbyemail/ tools/advancedsearch/ tools/benevolat/ tools/ferme/ tools/fontautoinstall/ tools/ipblock/ tools/lms/ tools/login-sso/ tools/logincas/ tools/loginldap/ tools/maintenance/ tools/multideletepages/ tools/nextcloudconnector/ tools/publication/ tools/qrcode/ tools/stats/ tools/tabdyn/ tools/twolevels/ tools/webhooks'
+	ynh_setup_source --dest_dir="$install_dir" --full-replace=1 --keep=".env wakka.config.php files/ custom/ private/ themes/ tools/accountactivationbyemail/ tools/advancedsearch/ tools/benevolat/ tools/ferme/ tools/fontautoinstall/ tools/ipblock/ tools/lms/ tools/login-sso/ tools/logincas/ tools/loginldap/ tools/maintenance/ tools/multideletepages/ tools/nextcloudconnector/ tools/publication/ tools/qrcode/ tools/stats/ tools/tabdyn/ tools/twolevels/ tools/webhooks"
 
 	ynh_replace_string --match_string="yeswiki_release' \?=> \?'.*',$" --replace_string="yeswiki_release' => '$(ynh_app_upstream_version)'," --target_file="$install_dir/wakka.config.php"
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -25,7 +25,7 @@ then
 
 	# Download, check integrity, uncompress and patch the source from app.src
 	# TODO : find a way to sync stable extensions list to avoid hardcoded extensions folders to keep
-	ynh_setup_source --dest_dir="$install_dir" --full-replace --keep='.env wakka.config.php files/ custom/ private/ themes/ tools/accountactivationbyemail/ tools/advancedsearch/ tools/benevolat/ tools/ferme/ tools/fontautoinstall/ tools/ipblock/ tools/lms/ tools/login-sso/ tools/logincas/ tools/loginldap/ tools/maintenance/ tools/multideletepages/ tools/nextcloudconnector/ tools/publication/ tools/qrcode/ tools/stats/ tools/tabdyn/ tools/twolevels/ tools/webhooks'
+	ynh_setup_source --dest_dir="$install_dir" --full-replace 1 --keep='.env wakka.config.php files/ custom/ private/ themes/ tools/accountactivationbyemail/ tools/advancedsearch/ tools/benevolat/ tools/ferme/ tools/fontautoinstall/ tools/ipblock/ tools/lms/ tools/login-sso/ tools/logincas/ tools/loginldap/ tools/maintenance/ tools/multideletepages/ tools/nextcloudconnector/ tools/publication/ tools/qrcode/ tools/stats/ tools/tabdyn/ tools/twolevels/ tools/webhooks'
 
 	ynh_replace_string --match_string="yeswiki_release' \?=> \?'.*',$" --replace_string="yeswiki_release' => '$(ynh_app_upstream_version)'," --target_file="$install_dir/wakka.config.php"
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,7 +24,8 @@ then
 	ynh_script_progression --message="Upgrading source files..." --weight=5
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$install_dir"
+	# TODO : find a way to sync stable extensions list to avoid hardcoded extensions folders to keep
+	ynh_setup_source --dest_dir="$install_dir" --full-replace --keep='.env wakka.config.php files/ custom/ private/ themes/ tools/accountactivationbyemail/ tools/advancedsearch/ tools/benevolat/ tools/ferme/ tools/fontautoinstall/ tools/ipblock/ tools/lms/ tools/login-sso/ tools/logincas/ tools/loginldap/ tools/maintenance/ tools/multideletepages/ tools/nextcloudconnector/ tools/publication/ tools/qrcode/ tools/stats/ tools/tabdyn/ tools/twolevels/ tools/webhooks'
 
 	ynh_replace_string --match_string="yeswiki_release' \?=> \?'.*',$" --replace_string="yeswiki_release' => '$(ynh_app_upstream_version)'," --target_file="$install_dir/wakka.config.php"
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -25,7 +25,7 @@ then
 
 	# Download, check integrity, uncompress and patch the source from app.src
 	# TODO : find a way to sync stable extensions list to avoid hardcoded extensions folders to keep
-	ynh_setup_source --dest_dir="$install_dir" --full-replace 1 --keep='.env wakka.config.php files/ custom/ private/ themes/ tools/accountactivationbyemail/ tools/advancedsearch/ tools/benevolat/ tools/ferme/ tools/fontautoinstall/ tools/ipblock/ tools/lms/ tools/login-sso/ tools/logincas/ tools/loginldap/ tools/maintenance/ tools/multideletepages/ tools/nextcloudconnector/ tools/publication/ tools/qrcode/ tools/stats/ tools/tabdyn/ tools/twolevels/ tools/webhooks'
+	ynh_setup_source --dest_dir="$install_dir" --full-replace=1 --keep='.env wakka.config.php files/ custom/ private/ themes/ tools/accountactivationbyemail/ tools/advancedsearch/ tools/benevolat/ tools/ferme/ tools/fontautoinstall/ tools/ipblock/ tools/lms/ tools/login-sso/ tools/logincas/ tools/loginldap/ tools/maintenance/ tools/multideletepages/ tools/nextcloudconnector/ tools/publication/ tools/qrcode/ tools/stats/ tools/tabdyn/ tools/twolevels/ tools/webhooks'
 
 	ynh_replace_string --match_string="yeswiki_release' \?=> \?'.*',$" --replace_string="yeswiki_release' => '$(ynh_app_upstream_version)'," --target_file="$install_dir/wakka.config.php"
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -25,7 +25,7 @@ then
 
 	# Download, check integrity, uncompress and patch the source from app.src
 	# TODO : find a way to sync stable extensions list to avoid hardcoded extensions folders to keep
-	ynh_setup_source --dest_dir="$install_dir" --full-replace=1 --keep=".env wakka.config.php files/ custom/ private/ themes/ tools/accountactivationbyemail/ tools/advancedsearch/ tools/benevolat/ tools/ferme/ tools/fontautoinstall/ tools/ipblock/ tools/lms/ tools/login-sso/ tools/logincas/ tools/loginldap/ tools/maintenance/ tools/multideletepages/ tools/nextcloudconnector/ tools/publication/ tools/qrcode/ tools/stats/ tools/tabdyn/ tools/twolevels/ tools/webhooks"
+	ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep=".env wakka.config.php files/ custom/ private/ themes/ tools/accountactivationbyemail/ tools/advancedsearch/ tools/benevolat/ tools/ferme/ tools/fontautoinstall/ tools/ipblock/ tools/lms/ tools/login-sso/ tools/logincas/ tools/loginldap/ tools/maintenance/ tools/multideletepages/ tools/nextcloudconnector/ tools/publication/ tools/qrcode/ tools/stats/ tools/tabdyn/ tools/twolevels/ tools/webhooks"
 
 	ynh_replace_string --match_string="yeswiki_release' \?=> \?'.*',$" --replace_string="yeswiki_release' => '$(ynh_app_upstream_version)'," --target_file="$install_dir/wakka.config.php"
 fi


### PR DESCRIPTION
## Problem

- the update was keeping older files in the folder, which was causing bugs
- one dep to php82-ldap was missing

## Solution

- erase source-dir before upgrade except for extension, themes, custom and config files
- add missing dep to manifest.toml
-  
## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
