### PR TITLE
Add ASYNC_PHP_BINARY env var in extra_php-fpm.conf

### DIFF
--- a/conf/extra_php-fpm.conf
+++ b/conf/extra_php-fpm.conf
@@ -2,3 +2,5 @@
 
 php_admin_value[upload_max_filesize] = 500M
 php_admin_value[post_max_size] = 500M
+; php binary to use for async processes
+env[ASYNC_PHP_BINARY] = /usr/bin/php8.2


### PR DESCRIPTION
## Problem

YesWiki fails to performs backups when installing or updating an extension or a theme.
The issue comes from having 2 php versions installed on the server : 7;4 and 8.2
The YesWiki php-fpm version is 8.2, but zhen it starts an async process to perform the backup its the php version 7.4 that is used.


## Solution

YesWiki code is changed to use an optional env var to define the php binary to use for async processes. See yhis PT : https://github.com/YesWiki/yeswiki/pull/1134
On YUNoHost side the env var is defined in the php-fpm pool configuration file

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
  - I have tested the fix by manually editing the files on a test server.

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
