### PR TITLE
Fix typo in upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -94,7 +94,7 @@ if [ $(grep yunohost_sso_domain "$install_dir/wakka.config.php" | wc -l) = "0" ]
 fi
 
 if [ $(grep yunohost-cli "$install_dir/wakka.config.php" | wc -l) != "0" ]; then
-  ynh_replace_string --match_string="'yunohost-cli'" --replace_string="'yunohost-apps'" --target_file="$install_dir/wakka.config.php"
+  ynh_replace --match="'yunohost-cli'" --replace="'yunohost-apps'" --file="$install_dir/wakka.config.php"
 fi
 # ToDo : Add app importer config in wakka.config.php if it is not already there ? (need to find a formid that is not already used)
 


### PR DESCRIPTION
## Problem

- https://paste.yunohost.org/raw/uvehimalel

```
2024-11-12 13:59:09,769: DEBUG - + ynh_replace_string '--match_string='\''yunohost-cli'\''' '--replace_string='\''yunohost-apps'\''' --target_file=/var/www/yeswiki__4/wakka.config.php
2024-11-12 13:59:09,769: WARNING - ./upgrade: line 97: ynh_replace_string: command not found
```

## Solution

- Helpers 2.1?

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
