### PR TITLE
Change checksum of importer plugin

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -110,7 +110,7 @@ sha256 = "d2f7077a699050d23363dc6fbb690800531fd0444c12271a28cfa051fac5985b"
 
 [resources.sources.importerplugin]
 url = "https://repository.yeswiki.net/doryphore/extension-importer-1.0.4.zip"
-sha256 = "5aeb62c002b5c4df84e5bf3d97c0c0e2868b103eb76d6f0b5acb8f8e52388bf1"
+sha256 = "134058aad4a8328a380255da3e1564972ccf85a4fae44df551ea41ba4073a756"
 
 [resources.sources.ferme]
 url = "https://repository.yeswiki.net/doryphore/extension-ferme-1.2.1.zip"


### PR DESCRIPTION
## Problem

- yeswiki cannot be installed any more due to wrong checksum

## Solution

- *And how do you fix that problem*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
